### PR TITLE
FE: Set Base Font Family

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,17 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Google Fonts preload -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Vue + TS</title>
+    <title>Ria Weather App Assessment</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -4,7 +4,7 @@
 
 /* ── SMOKE TEST ── */
 @layer base {
-  body {
-    background-color: #f0f0f0;
+  html {
+    @apply font-sans;
   }
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -16,6 +16,20 @@ export default {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: [
+          "Inter",
+          "system-ui",
+          "-apple-system",
+          "BlinkMacSystemFont",
+          '"Segoe UI"',
+          '"Roboto"',
+          '"Helvetica Neue"',
+          '"Arial"',
+          '"Noto Sans"',
+          "sans-serif",
+        ],
+      },
       colors: {
         textPrimary: "#1B1B1B",
         textSecondary: "#808080",


### PR DESCRIPTION
## 🚀 Overview

**Issue link:** [#6 ](https://github.com/vneilly/ria-weather-app-assessment/issues/6)  
**Branch:** feature/6-set-fonts-family

Configure Inter as the project’s base sans-serif font with robust system fallbacks and apply it globally.

---

## 🛠 Changes

- Added Google Fonts preload and stylesheet link for Inter in index.html  
- Extended `theme.extend.fontFamily.sans` in tailwind.config.mjs to `['Inter', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', 'Noto Sans', 'sans-serif']`  
- Applied `font-sans` to the `html` element via `@apply` in src/assets/index.css

---

## 🔍 How to Test

1. Checkout the branch and install dependencies  
   - git checkout fe/set-base-font-family  
   - npm install  
2. Start the dev server  
   - npm run dev  
3. Confirm that:  
   - All text throughout the app uses the Inter font (check in browser dev-tools under Computed → font-family)  
   - Fallbacks apply correctly when Inter fails to load

---

## ✅ Checklist

- [x] Feature Implementation  
- [ ] Bug Fix  
- [ ] Dependencies added or updated  
- [ ] Code Refactoring  
- [ ] Documentation Update  
- [ ] Performance Improvement  

---

Closes #6  




