### PR TITLE
FE: Build Static City Tabs Component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import Header from "@/components/Header.vue";
+import ForecastView from "@/views/ForecastView.vue";
 </script>
 
 <template>
@@ -7,5 +8,7 @@ import Header from "@/components/Header.vue";
   <Header />
 
   <!-- Main Content -->
-  <main class="pt-16"></main>
+  <main class="pt-16">
+    <ForecastView />
+  </main>
 </template>

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+// props and emits will be defined here
+import { defineProps, defineEmits } from "vue";
+</script>
+
+<template>
+  <!-- Tab buttons will go here -->
+</template>

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 // props and emits will be defined here
 import { defineProps, defineEmits } from "vue";
-import { CITY_LIST, City } from "@/constants/cityList";
+import { City } from "@/constants/cityList";
 
 interface TabProps {
   cities: City[];

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -15,7 +15,7 @@ interface TabEmits {
 const props = defineProps<TabProps>();
 const emit = defineEmits<TabEmits>();
 
-const getTabClasses(city: City) => {
+const getTabClasses = (city: City) => {
   const base = "focus:outline-none cursor-pointer px-4 py-2";
   const activeStyles = "text-textPrimary font-semibold";
   const inactiveStyles = "text-textSecondary hover:text-accent";

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -1,8 +1,42 @@
 <script setup lang="ts">
 // props and emits will be defined here
 import { defineProps, defineEmits } from "vue";
+import { CITY_LIST, City } from "@/constants/cityList";
+
+interface TabProps {
+  cities: City[];
+  active: City;
+}
+
+interface TabEmits {
+  (e: "select", city: City): void;
+}
+
+const props = defineProps<TabProps>();
+const emit = defineEmits<TabEmits>();
+
+const getTabClasses(city: City) => {
+  const base = "focus:outline-none cursor-pointer px-4 py-2";
+  const activeStyles = "text-textPrimary font-semibold";
+  const inactiveStyles = "text-textSecondary hover:text-accent";
+
+  return `${base} ${
+    city.id === props.active.id ? activeStyles : inactiveStyles
+  }`;
+};
 </script>
 
 <template>
   <!-- Tab buttons will go here -->
+  <div class="flex space-x-4">
+    <button
+      v-for="city in props.cities"
+      :key="city"
+      :class="getTabClasses(city)"
+      type="button"
+      @click="emit('select', city)"
+    >
+      {{ city }}
+    </button>
+  </div>
 </template>

--- a/src/constants/cities.ts
+++ b/src/constants/cities.ts
@@ -1,0 +1,11 @@
+export interface City {
+  id: number;
+  name: string;
+  country: string;
+}
+
+export const CITY_LIST: City[] = [
+  { id: 3451190, name: "Rio de Janeiro", country: "BR" },
+  { id: 1816670, name: "Beijing", country: "CN" },
+  { id: 5368361, name: "Los Angeles", country: "US" },
+];

--- a/src/views/ForecastView.vue
+++ b/src/views/ForecastView.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { Tabs } from "@/components/Tabs.vue";
-import { City, CITY_LIST } from "@/constants/cityList";
+import Tabs from "@/components/Tabs.vue";
+import { City, CITY_LIST } from "@/constants/cities";
 
-const activeCity = ref<City>(CITY_LIST[0]);
+const activeCity = ref<City>(CITY_LIST[2]);
 
 const handleCitySelect = (city: City) => {
   activeCity.value = city;

--- a/src/views/ForecastView.vue
+++ b/src/views/ForecastView.vue
@@ -1,21 +1,21 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref } from "vue";
 import { Tabs } from "@/components/Tabs.vue";
+import { City, CITY_LIST } from "@/constants/cityList";
 
-const activeCity = ref("Los Angeles");
+const activeCity = ref<City>(CITY_LIST[0]);
 
-const handleSetActiveCity = (city: string) => {
+const handleCitySelect = (city: City) => {
   activeCity.value = city;
+  // TBD: Add logic to fetch weather data for the selected city
 };
 </script>
 
 <template>
   <div>
     <!-- Tabs will be added here -->
-    <Tabs
-      :cities="['Los Angeles', 'New York', 'Chicago']"
-      :active="activeCity"
-      @select="activeCity = $event"
-    />
+    <Tabs :cities="CITY_LIST" :active="activeCity" @select="handleCitySelect" />
+
+    <!-- Hourly Forecast Section -->
   </div>
 </template>

--- a/src/views/ForecastView.vue
+++ b/src/views/ForecastView.vue
@@ -1,11 +1,21 @@
 <script setup lang="ts">
-// Future imports and state will be added here
+import { ref, watch } from "vue";
+import { Tabs } from "@/components/Tabs.vue";
+
+const activeCity = ref("Los Angeles");
+
+const handleSetActiveCity = (city: string) => {
+  activeCity.value = city;
+};
 </script>
 
 <template>
-  <!-- Tabs will be added here -->
-  <div class="forecast-view">
-    <h1>Forecast View</h1>
-    <p>This is the forecast view.</p>
+  <div>
+    <!-- Tabs will be added here -->
+    <Tabs
+      :cities="['Los Angeles', 'New York', 'Chicago']"
+      :active="activeCity"
+      @select="activeCity = $event"
+    />
   </div>
 </template>

--- a/src/views/ForecastView.vue
+++ b/src/views/ForecastView.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+// Future imports and state will be added here
+</script>
+
+<template>
+  <!-- Tabs will be added here -->
+  <div class="forecast-view">
+    <h1>Forecast View</h1>
+    <p>This is the forecast view.</p>
+  </div>
+</template>


### PR DESCRIPTION
## 🚀 Overview
**Issue link:** [#8](https://github.com/vneilly/ria-weather-app-assessment/issues/8)  
**Branch:** `feature/8-static-city-tabs`  

Adds a reusable `Tabs` component backed by a typed `City` list and integrates it into `ForecastView.vue` to manage city selection.

---

## 🛠 Changes
- Scaffolded `ForecastView.vue` as the parent view  
- Created `City` interface and `CITY_LIST` constant in `src/constants/city.ts`  
- Scaffolded `Tabs.vue` component (props/emits defined)  
- Implemented `getTabClasses` helper for styling based on `activeCity`  
- Integrated `<Tabs>` into `ForecastView.vue` with `activeCity` state and `handleCitySelect`  

---

## 🔍 How to Test
1. `git checkout feature/8-static-city-tabs`  
2. `npm install`  
3. `npm run dev`  
4. Verify:  
   - Three tabs (“Rio de Janeiro”, “Beijing”, “Los Angeles”) render horizontally  
   - Active tab uses `text-textPrimary font-semibold`; others use `text-textSecondary hover:text-accent`  
   - Clicking a tab updates the highlighted state  

---

## ✅ Checklist
- [x] Feature Implementation  
- [ ] Bug Fix  
- [ ] Dependencies added or updated  
- [ ] Code Refactoring  
- [ ] Documentation Update  
- [ ] Performance Improvement  

---

Closes #8