### PR TITLE
FE: Build HourlyForecast Component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@ import ForecastView from "@/views/ForecastView.vue";
   <Header />
 
   <!-- Main Content -->
-  <main class="pt-16">
+  <main class="container mx-auto px-4 pt-16">
     <ForecastView />
   </main>
 </template>

--- a/src/components/HourlyForecast.vue
+++ b/src/components/HourlyForecast.vue
@@ -3,26 +3,28 @@ import { defineProps } from "vue";
 import WeatherIcon from "./WeatherIcon.vue";
 
 interface HourlyViewProps {
-  time: string;
   temp: number;
-  icon: string;
   humidity: number;
+  icon: string;
+  time: string;
 }
 
-const props = defineProps<forecast: HourlyViewProps[]>();
+const props = defineProps<{ hours: HourlyViewProps[] }>();
 </script>
 
 <template>
-  <div class="hourly-forecast flex space-x-4 overflow-x-auto">
+  <div class="hourly-forecast flex space-x-4 overflow-x-auto scroll-smooth">
     <div
-      v-for="hour in forecast"
+      v-for="hour in props.hours"
       :key="hour.time"
-      class="flex flex-col items-center p-2 rounded-lg"
+      class="w-24 flex-shrink-0 snap-start bg-white border border-gray-200 p-4 rounded-lg text-center"
     >
-      <span class="text-lg font-medium">{{ hour.temp }}&deg;</span>
-      <span class="text-xs">{{ hour.humidity }}&#37;</span>
-      <WeatherIcon :code="hour.icon" size="2" />
-      <span class="text-sm">{{ hour.time }}</span>
+      <span class="text-lg font-medium block">{{ hour.temp }}&deg;</span>
+      <span class="text-xs text-blue-400 block mt-1"
+        >{{ hour.humidity }}&#37;</span
+      >
+      <WeatherIcon :code="hour.icon" :size="2" />
+      <span class="text-sm block mt-1">{{ hour.time }}</span>
     </div>
   </div>
 </template>

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-// props and emits will be defined here
-import { defineProps, defineEmits } from "vue";
+import { defineProps } from "vue";
 import { City } from "@/constants/cityList";
 
 interface TabProps {

--- a/src/components/WeatherIcon.vue
+++ b/src/components/WeatherIcon.vue
@@ -1,3 +1,19 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+interface WeatherIconProps {
+  code: string;
+  size: number;
+}
+
+const props = defineProps<WeatherIconProps>();
+
+const iconUrl = computed(
+  () => `https://openweathermap.org/img/wn/${props.code}@${props.size}x.png`
+);
+const altText = computed(() => `Weather icon for ${props.code}`);
+</script>
+
 <template>
   <img
     :src="iconUrl"
@@ -6,14 +22,3 @@
     loading="lazy"
   />
 </template>
-
-<script setup lang="ts">
-import { defineProps, computed } from "vue";
-
-interface WeatherIconProps {
-  code: string;
-  size?: number;
-}
-
-const props = defineProps<WeatherIconProps>();
-</script>

--- a/src/views/ForecastView.vue
+++ b/src/views/ForecastView.vue
@@ -4,12 +4,33 @@ import Tabs from "@/components/Tabs.vue";
 import { City, CITY_LIST } from "@/constants/cities";
 import { getWeather } from "@/services/weather";
 
+import HourlyForecast from "@/components/HourlyForecast.vue";
+import type { HourlyViewProps } from "@/components/HourlyForecast.vue";
+
 const activeCity = ref<City>(CITY_LIST[2]);
+
+const hourlyData = ref<HourlyViewProps[]>([]);
 
 const fetchWeatherData = async (city: City) => {
   try {
     const weatherData = await getWeather(city);
-    console.log("Weather data:", weatherData);
+    console.log("Weather Data:", weatherData);
+    if (!weatherData || !weatherData.list) {
+      console.error("Invalid weather data format");
+      return;
+    }
+
+    hourlyData.value = weatherData.list.slice(0, 12).map((hour) => ({
+      temp: hour.main.temp,
+      humidity: hour.main.humidity,
+      icon: hour.weather[0].icon,
+      time: new Date(hour.dt * 1000).toLocaleTimeString(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+      }),
+    }));
+
+    console.log("Mapped Hourly Data:", hourlyData.value);
   } catch (error) {
     console.error("Error fetching weather data:", error);
   }
@@ -34,7 +55,11 @@ onMounted(async () => {
     <div class="mt-6 text-gray-500">
       <h2 class="text-2xl font-bold">Hourly Forecast</h2>
       <p class="mt-2">Detailed hourly forecast for {{ activeCity.name }}</p>
-      <!-- Add hourly forecast component here -->
+
+      <!-- hourly forecast component here -->
+      <div class="mt-4">
+        <HourlyForecast :hours="hourlyData" />
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## 🚀 Overview

**Issue link:** [#10 ](https://github.com/vneilly/ria-weather-app-assessment/issues/10)  
**Branch:** `feature/10-hourly-forecast`

Add a new `HourlyForecast` component to display a horizontally scrollable list of hourly weather cards.

---

## 🛠 Changes

- Created `HourlyForecast.vue` with `hours` prop and `HourlyViewProps` interface.  
- Styled each card (`w-24`, `p-4`, border, white bg, rounded corners) and container (`flex space-x-4 overflow-x-auto`).  
- Added `WeatherIcon.vue` component to load icons dynamically from OpenWeatherMap.  
- Updated `ForecastView.vue` to fetch, map, and pass first 12 hourly data points to `<HourlyForecast>`.

---

## 🔍 How to Test

1. Check out this branch and install dependencies  
   - git checkout feature/hourly-forecast  
   - npm install  
2. Run the dev server  
   - npm run dev  
3. Confirm that:  
   - Selecting a city loads the “Hourly Forecast” section.  
   - A row of 12 cards appears showing temperature, humidity, weather icon, and formatted local time.  
   - The cards scroll smoothly horizontally (trackpad swipe or scrollbar).

---

## ✅ Checklist

- [x] Feature Implementation  
- [ ] Bug Fix  
- [ ] Dependencies added or updated  
- [ ] Code Refactoring  
- [ ] Documentation Update  
- [ ] Performance Improvement  

Closes #10 

