### PR TITLE
FE: Build DailyForecast Component

### DIFF
--- a/src/components/DailyForecast.vue
+++ b/src/components/DailyForecast.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import WeatherIcon from "@/components/WeatherIcon.vue";
+export interface DailyForecastItem {
+  day: string;
+  date: string;
+  description: string;
+  icon: string;
+  high: number;
+  low: number;
+  formattedDate: string;
+}
+
+const props = defineProps<{
+  summaries: DailyForecastItem[];
+}>();
+</script>
+
+<template>
+  <div class="daily-forecast bg-white rounded-lg divide-y divide-gray-200 p-4">
+    <div
+      v-for="day in props.summaries"
+      :key="day.date"
+      class="flex items-center justify-between px-4 py-4"
+    >
+      <!-- Left: WeatherIcon -->
+      <WeatherIcon :code="day.icon" :size="2" class="w-24 h-24 flex-shrink-0" />
+
+      <!-- Middle: Day/Date and Description -->
+      <div>
+        <div class="text-2xl text-gray-600">
+          {{ day.formattedDate }}
+        </div>
+
+        <!-- Description -->
+        <div class="text-base text-gray-500">
+          {{ day.description }}
+        </div>
+      </div>
+      <!-- Right: Hi/Lo temps -->
+      <div class="flex space-x-2 text-base font-medium text-gray-800">
+        <span>{{ day.maxTemp }}&deg;</span>
+        <span>{{ day.minTemp }}&deg;</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/HourlyForecast.vue
+++ b/src/components/HourlyForecast.vue
@@ -2,7 +2,7 @@
 import { defineProps } from "vue";
 import WeatherIcon from "./WeatherIcon.vue";
 
-interface HourlyViewProps {
+export interface HourlyViewProps {
   temp: number;
   humidity: number;
   icon: string;

--- a/src/components/WeatherIcon.vue
+++ b/src/components/WeatherIcon.vue
@@ -18,7 +18,8 @@ const altText = computed(() => `Weather icon for ${props.code}`);
   <img
     :src="iconUrl"
     :alt="altText"
-    class="inline-block w-8 h-8"
+    class="inline-block"
     loading="lazy"
+    v-bind="$attrs"
   />
 </template>

--- a/src/composables/useWeatherData.ts
+++ b/src/composables/useWeatherData.ts
@@ -1,0 +1,53 @@
+import { ref } from "vue";
+
+import type { City } from "@/constants/cities";
+import type { HourlyViewProps } from "@/components/HourlyForecast.vue";
+import type { DailySummary } from "@/types/weatherTypes";
+
+import { getWeather } from "@/services/weather";
+import { groupByLocalDate, getDailySummaries } from "@/services/dataMappers";
+
+export const useWeatherData = () => {
+  // State variables
+  const hourlyData = ref<HourlyViewProps[]>([]);
+  const dailySummaries = ref<DailySummary[]>([]);
+
+  //   Loading and error states
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  const fetchForCity = async (city: City) => {
+    loading.value = true;
+    error.value = null;
+
+    try {
+      const weatherData = await getWeather(city);
+      console.log("Weather Data:", weatherData);
+
+      hourlyData.value = weatherData.list.slice(0, 12).map((hour) => ({
+        temp: hour.main.temp,
+        humidity: hour.main.humidity,
+        icon: hour.weather[0].icon,
+        time: new Date(hour.dt * 1000).toLocaleTimeString(undefined, {
+          hour: "numeric",
+          minute: "2-digit",
+        }),
+      }));
+
+      console.log("Mapped Hourly Data:", hourlyData.value);
+      const grouped = groupByLocalDate(weatherData.list);
+      dailySummaries.value = getDailySummaries(grouped);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        error.value = err.message;
+      } else {
+        error.value = String(err);
+      }
+      console.error("Error fetchForCity:", error);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  return { hourlyData, dailySummaries, loading, error, fetchForCity };
+};

--- a/src/services/dataMappers.ts
+++ b/src/services/dataMappers.ts
@@ -1,0 +1,71 @@
+import type { ForecastListItem, DailySummary } from "@/types/weatherTypes";
+
+export const groupByLocalDate = (
+  items: ForecastListItem[]
+): Record<string, ForecastListItem[]> =>
+  items.reduce((acc, item) => {
+    const localDate = new Date(item.dt * 1000).toLocaleDateString(undefined, {
+      timeZone: "UTC",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    if (!acc[localDate]) {
+      acc[localDate] = [];
+    }
+    acc[localDate].push(item);
+    return acc;
+  }, {} as Record<string, ForecastListItem[]>);
+
+export const getDailySummaries = (
+  groupedItems: Record<string, ForecastListItem[]>
+): DailySummary[] => {
+  const entries = Object.entries(groupedItems);
+  // Sort the entries by date
+  const sortedEntries = entries.sort(([dateA], [dateB]) => {
+    const dateAObj = new Date(dateA);
+    const dateBObj = new Date(dateB);
+    return dateAObj.getTime() - dateBObj.getTime();
+  });
+
+  // extract first 5 entries
+  const firstFiveEntries = sortedEntries.slice(0, 5);
+
+  const dailySummaries: DailySummary[] = [];
+  for (const [date, items] of firstFiveEntries) {
+    // get all temps for the day
+    const temps = items.map((item) => item.main.temp);
+    // get min and max temps
+    const minTemp = Math.min(...temps);
+    const maxTemp = Math.max(...temps);
+
+    // get HiTemp and icon
+    const hiTempItem = items.find((item) => item.main.temp === maxTemp);
+
+    const icon = hiTempItem?.weather[0].icon || "01d"; // default to clear sky icon if not found
+    const rawDescription = hiTempItem?.weather[0].description || "Clear sky"; // default to clear sky if not found
+    const description =
+      rawDescription.charAt(0).toUpperCase() + rawDescription.slice(1); // Capitalize the first letter
+
+    const dayLabel = new Date(date).toLocaleDateString(undefined, {
+      weekday: "short",
+    });
+    const formattedDate = new Date(date).toLocaleDateString(undefined, {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    });
+
+    dailySummaries.push({
+      date,
+      dayLabel,
+      minTemp,
+      maxTemp,
+      icon,
+      formattedDate,
+      description,
+    });
+  }
+
+  return dailySummaries;
+};

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -1,10 +1,11 @@
 import axios from "axios";
 
 import type { City } from "@/constants/cities";
+import type { ForecastData } from "@/types/weatherTypes";
 
 const API_URL_BASE = "https://api.openweathermap.org/data/2.5/forecast";
 console.log("🔑 API_KEY:", import.meta.env.VITE_API_KEY);
-export const getWeather = async (city: City) => {
+export const getWeather = async (city: City): Promise<ForecastData> => {
   const API_KEY = import.meta.env.VITE_API_KEY;
 
   if (!API_KEY) {

--- a/src/types/weatherTypes.ts
+++ b/src/types/weatherTypes.ts
@@ -1,0 +1,37 @@
+export interface ForecastListItem {
+  dt: number;
+  dt_txt: string;
+  main: {
+    temp: number;
+    temp_min: number;
+    temp_max: number;
+    humidity: number;
+  };
+  weather: {
+    description: string;
+    icon: string;
+  }[];
+}
+
+export interface ForecastData {
+  city: {
+    name: string;
+    country: string;
+    id: number;
+    coord: {
+      lat: number;
+      lon: number;
+    };
+  };
+  list: ForecastListItem[];
+}
+
+export interface DailySummary {
+  date: string;
+  description: string;
+  minTemp: number;
+  maxTemp: number;
+  icon: string;
+  dayLabel: string;
+  formattedDate: string;
+}


### PR DESCRIPTION
🚀 Overview
Issue link: [#11](https://github.com/vneilly/ria-weather-app-assessment/issues/11)
Branch: feature/daily-forecast

Add a vertical “Next 5 Days” forecast section with a new DailyForecast component.

🛠 Changes
Created DailyForecast.vue to render five day cards

Wired up useWeatherData to supply formatted date, description, icon, and high/low temps

Styled cards using Tailwind utilities (divide-y, spacing, typography, responsive sizing)

Integrated the component into ForecastView.vue under the “Next 5 Days” header

🔍 How to Test
Check out this branch and install dependencies

Run the dev server

Confirm that:

A “Next 5 Days” section appears below the hourly forecast

Exactly five cards display, each showing a weather icon, formatted date (e.g. “Friday, May 2”), description, and side-by-side high/low temperatures

Divider lines, font sizes, and spacing align with the mock UI

✅ Checklist
 Feature Implementation

 Bug Fix

 Dependencies added or updated

 Code Refactoring

 Documentation Update

 Performance Improvement

Closes #11
